### PR TITLE
When no window handle is given, we take the current one

### DIFF
--- a/ddraw/IDirectDrawX.cpp
+++ b/ddraw/IDirectDrawX.cpp
@@ -2619,6 +2619,12 @@ HRESULT m_IDirectDrawX::CreateD3D9Device()
 		// Get hwnd
 		HWND hWnd = GetHwnd();
 
+		// get current window if none is set
+		if(hWnd == nullptr)
+		{
+			hWnd = GetActiveWindow();
+		}
+
 		// Store new focus window
 		hFocusWindow = hWnd;
 


### PR DESCRIPTION
When no window handle is given, we take the current one,  which can pevent freezes during CreateDevice.