### PR TITLE
Fix rare buffer overflow in `EnumDisplaySettingsEx` hook

### DIFF
--- a/DDrawCompat/v0.3.1/Win32/DisplayMode.cpp
+++ b/DDrawCompat/v0.3.1/Win32/DisplayMode.cpp
@@ -188,7 +188,7 @@ namespace
 
 			DWORD modeNum = 0;
 			DevMode dm = {};
-			dm.dmSize = sizeof(dm);
+			dm.dmSize = lpDevMode->dmSize;
 			while (origEnumDisplaySettingsEx(lpszDeviceName, modeNum, &dm, dwFlags))
 			{
 				if (32 == dm.dmBitsPerPel)
@@ -209,7 +209,7 @@ namespace
 			return FALSE;
 		}
 
-		*lpDevMode = devModes[iModeNum];
+		memcpy_s(lpDevMode, lpDevMode->dmSize, &devModes[iModeNum], lpDevMode->dmSize);
 		return TRUE;
 	}
 

--- a/DDrawCompat/v0.3.1/Win32/DisplayMode.cpp
+++ b/DDrawCompat/v0.3.1/Win32/DisplayMode.cpp
@@ -159,7 +159,7 @@ namespace
 	BOOL enumDisplaySettingsEx(EnumDisplaySettingsExFunc origEnumDisplaySettingsEx,
 		const Char* lpszDeviceName, DWORD iModeNum, DevMode* lpDevMode, DWORD dwFlags)
 	{
-		if (ENUM_REGISTRY_SETTINGS == iModeNum || !lpDevMode)
+		if (ENUM_REGISTRY_SETTINGS == iModeNum || !lpDevMode || !lpDevMode->dmSize)
 		{
 			BOOL result = origEnumDisplaySettingsEx(lpszDeviceName, iModeNum, lpDevMode, dwFlags);
 			return result;
@@ -188,7 +188,7 @@ namespace
 
 			DWORD modeNum = 0;
 			DevMode dm = {};
-			dm.dmSize = lpDevMode->dmSize;
+			dm.dmSize = min(lpDevMode->dmSize, sizeof(dm));
 			while (origEnumDisplaySettingsEx(lpszDeviceName, modeNum, &dm, dwFlags))
 			{
 				if (32 == dm.dmBitsPerPel)
@@ -209,7 +209,7 @@ namespace
 			return FALSE;
 		}
 
-		memcpy_s(lpDevMode, lpDevMode->dmSize, &devModes[iModeNum], lpDevMode->dmSize);
+		memcpy_s(lpDevMode, lpDevMode->dmSize, &devModes[iModeNum], min(lpDevMode->dmSize, sizeof(DevMode)));
 		return TRUE;
 	}
 


### PR DESCRIPTION
Please see https://github.com/elishacloud/dxwrapper/issues/272. Looking a bit more at the technical details, I discovered the following: 
Since I am using a rather old C++ compiler to build my plugin, `sizeof(DEVMODEA)` actually evaluates to 148, not 156. As a result, my plugin allocates 148 bytes on the stack for the device mode struct. When dxwrapper's `EnumDisplaySettingsExA` hook modifies the value that `lpDevMode` points to, it assumes 156 bytes, causing it to overwrite eight stack bytes too many.

This pull request makes it so that the device mode size in the `enumDisplaySettingsEx` function is no longer assumed, but instead uses the `dmSize` value that the caller passes. These changes fix the issue I've mentioned, and in my opinion it's the simplest way to go about it. However, with this approach the `devModes` vector will still store those eight additional bytes per element when they're not necessary. Though given the circumstances, fixing this the "ideal" way may be a bit difficult. I am open to any other suggestions.

Resolves https://github.com/elishacloud/dxwrapper/issues/272.