### PR TITLE
Added ability to configure settings via environment variables.

### DIFF
--- a/Settings/Settings.cpp
+++ b/Settings/Settings.cpp
@@ -531,6 +531,27 @@ void CONFIG::Init()
 	// Set default settings
 	SetDefaultConfigSettings();
 
+	// Set settings from environment variables
+	if (LPCH p_envStrings = GetEnvironmentStrings(); p_envStrings)
+	{
+		const char* szEnvPrefix = "DXWRAPPER_";
+		char* szEnvVar = p_envStrings;
+		char szSetting[MAX_ENV_VAR] = {};
+
+		while (*szEnvVar)
+		{
+			if (!_strnicmp(szEnvVar, szEnvPrefix, strlen(szEnvPrefix)))
+			{
+				szEnvVar += strlen(szEnvPrefix);
+				strcpy_s(szSetting, MAX_ENV_VAR, szEnvVar);
+				Parse(szSetting, ParseCallback);
+			}
+			szEnvVar += strlen(szEnvVar) + 1;
+		}
+
+		FreeEnvironmentStrings(p_envStrings);
+	}
+
 	// Check for memory loading
 	if (_stricmp(p_wName, p_pName) == 0)
 	{

--- a/Settings/Settings.h
+++ b/Settings/Settings.h
@@ -7,6 +7,7 @@
 #include "ReadParse.h"
 
 #define NOT_EXIST 0xFFFF
+#define MAX_ENV_VAR 0x7FFF
 
 #define VISIT_CONFIG_SETTINGS(visit) \
 	visit(AnisotropicFiltering) \


### PR DESCRIPTION
This enables configuring dxwrapper via environment variables. The primary use-case for this is to be able to programmatically configure dxwrapper without files within other game fixes (provided they initialize before dxwrapper does), as discussed in #367. 

The environment variables named identically to the keys in the INI files, but with a "DXWRAPPER_" prefix, and are case insensitive. They apply on top of the default settings, but are overwritten by any settings present in any INI file.