### PR TITLE
[Dd7To9] Remove D3DLOCK_DONOTWAIT flag from textures before locking them

### DIFF
--- a/Dllmain/BuildNo.rc
+++ b/Dllmain/BuildNo.rc
@@ -1,1 +1,1 @@
-#define BUILD_NUMBER 7845 
+#define BUILD_NUMBER 7846 

--- a/ddraw/IDirectDrawSurfaceX.cpp
+++ b/ddraw/IDirectDrawSurfaceX.cpp
@@ -8262,6 +8262,7 @@ HRESULT m_IDirectDrawSurfaceX::LockD3d9Surface(D3DLOCKED_RECT* pLockedRect, RECT
 	// Lock surface texture
 	else if (surface.Texture)
 	{
+		Flags &= ~D3DLOCK_DONOTWAIT;
 		HRESULT hr = surface.Texture->LockRect(GetD3d9MipMapLevel(MipMapLevel), pLockedRect, pRect, Flags);
 		if (FAILED(hr) && (Flags & D3DLOCK_NOSYSLOCK))
 		{


### PR DESCRIPTION
D3D9 does not allow the D3DLOCK_DONOTWAIT flag to be used when locking textures. This caused textures to fail to lock when d3d9to9ex was enabled, and was still undefined behaviour on regular D3D9.