### PR TITLE
Fix GetDisplayMode for D3d9to9Ex

### DIFF
--- a/Dllmain/BuildNo.rc
+++ b/Dllmain/BuildNo.rc
@@ -1,1 +1,1 @@
-#define BUILD_NUMBER 7890 
+#define BUILD_NUMBER 7891 

--- a/d3d9/IDirect3DDevice9Ex.cpp
+++ b/d3d9/IDirect3DDevice9Ex.cpp
@@ -779,18 +779,18 @@ HRESULT m_IDirect3DDevice9Ex::GetDisplayMode(THIS_ UINT iSwapChain, D3DDISPLAYMO
 
 	if (Config.D3d9to9Ex && ProxyInterfaceEx)
 	{
-		D3DDISPLAYMODEEX* pModeEx = nullptr;
 		D3DDISPLAYMODEEX ModeEx = {};
-
-		if (pMode)
-		{
-			ModeToModeEx(*pMode, ModeEx);
-			pModeEx = &ModeEx;
-		}
-
+		ModeEx.Size = sizeof(D3DDISPLAYMODEEX);
 		D3DDISPLAYROTATION Rotation = D3DDISPLAYROTATION_IDENTITY;
 
-		return GetDisplayModeEx(iSwapChain, pModeEx, &Rotation);
+		HRESULT result = GetDisplayModeEx(iSwapChain, &ModeEx, &Rotation);
+		if (result != D3D_OK || !pMode)
+		{
+			return D3DERR_INVALIDCALL;
+		}
+
+		ModeExToMode(ModeEx, *pMode);
+		return D3D_OK;
 	}
 
 	return ProxyInterface->GetDisplayMode(iSwapChain, pMode);
@@ -3213,14 +3213,12 @@ void m_IDirect3DDevice9Ex::ReInitInterface() const
 	}
 }
 
-void m_IDirect3DDevice9Ex::ModeToModeEx(D3DDISPLAYMODE& Mode, D3DDISPLAYMODEEX& ModeEx)
+void m_IDirect3DDevice9Ex::ModeExToMode(D3DDISPLAYMODEEX& ModeEx, D3DDISPLAYMODE& Mode)
 {
-	ModeEx.Size = sizeof(D3DDISPLAYMODEEX);
-	ModeEx.Width = Mode.Width;
-	ModeEx.Height = Mode.Height;
-	ModeEx.RefreshRate = Mode.RefreshRate;
-	ModeEx.Format = Mode.Format;
-	ModeEx.ScanLineOrdering = D3DSCANLINEORDERING_PROGRESSIVE;
+	Mode.Width = ModeEx.Width;
+	Mode.Height = ModeEx.Height;
+	Mode.RefreshRate = ModeEx.RefreshRate;
+	Mode.Format = ModeEx.Format;
 }
 
 void m_IDirect3DDevice9Ex::LimitFrameRate() const

--- a/d3d9/IDirect3DDevice9Ex.cpp
+++ b/d3d9/IDirect3DDevice9Ex.cpp
@@ -779,18 +779,23 @@ HRESULT m_IDirect3DDevice9Ex::GetDisplayMode(THIS_ UINT iSwapChain, D3DDISPLAYMO
 
 	if (Config.D3d9to9Ex && ProxyInterfaceEx)
 	{
-		D3DDISPLAYMODEEX ModeEx = {};
-		ModeEx.Size = sizeof(D3DDISPLAYMODEEX);
-		D3DDISPLAYROTATION Rotation = D3DDISPLAYROTATION_IDENTITY;
-
-		HRESULT result = GetDisplayModeEx(iSwapChain, &ModeEx, &Rotation);
-		if (result != D3D_OK || !pMode)
+		if (!pMode)
 		{
 			return D3DERR_INVALIDCALL;
 		}
 
-		ModeExToMode(ModeEx, *pMode);
-		return D3D_OK;
+		D3DDISPLAYMODEEX ModeEx = {};
+		ModeEx.Size = sizeof(D3DDISPLAYMODEEX);
+		D3DDISPLAYROTATION Rotation = D3DDISPLAYROTATION_IDENTITY;
+
+		HRESULT hr = GetDisplayModeEx(iSwapChain, &ModeEx, &Rotation);
+
+		if (SUCCEEDED(hr))
+		{
+			ModeExToMode(ModeEx, *pMode);
+		}
+
+		return hr;
 	}
 
 	return ProxyInterface->GetDisplayMode(iSwapChain, pMode);

--- a/d3d9/IDirect3DDevice9Ex.h
+++ b/d3d9/IDirect3DDevice9Ex.h
@@ -340,6 +340,6 @@ public:
 	REFIID GetIID() { return WrapperID; }
 
 	// Static functions
-	static void m_IDirect3DDevice9Ex::ModeToModeEx(D3DDISPLAYMODE& Mode, D3DDISPLAYMODEEX& ModeEx);
+	static void m_IDirect3DDevice9Ex::ModeExToMode(D3DDISPLAYMODEEX& ModeEx, D3DDISPLAYMODE& Mode);
 };
 #undef SHARED

--- a/d3d9/IDirect3DSwapChain9Ex.cpp
+++ b/d3d9/IDirect3DSwapChain9Ex.cpp
@@ -111,18 +111,18 @@ HRESULT m_IDirect3DSwapChain9Ex::GetDisplayMode(THIS_ D3DDISPLAYMODE* pMode)
 
 	if (Config.D3d9to9Ex && ProxyInterfaceEx)
 	{
-		D3DDISPLAYMODEEX* pModeEx = nullptr;
 		D3DDISPLAYMODEEX ModeEx = {};
-
-		if (pMode)
-		{
-			m_IDirect3DDevice9Ex::ModeToModeEx(*pMode, ModeEx);
-			pModeEx = &ModeEx;
-		}
-
+		ModeEx.Size = sizeof(D3DDISPLAYMODEEX);
 		D3DDISPLAYROTATION Rotation = D3DDISPLAYROTATION_IDENTITY;
 
-		return GetDisplayModeEx(pModeEx, &Rotation);
+		HRESULT result = GetDisplayModeEx(&ModeEx, &Rotation);
+		if (result != D3D_OK || !pMode)
+		{
+			return D3DERR_INVALIDCALL;
+		}
+
+		m_IDirect3DDevice9Ex::ModeExToMode(ModeEx, *pMode);
+		return D3D_OK;
 	}
 
 	return ProxyInterface->GetDisplayMode(pMode);

--- a/d3d9/IDirect3DSwapChain9Ex.cpp
+++ b/d3d9/IDirect3DSwapChain9Ex.cpp
@@ -111,18 +111,23 @@ HRESULT m_IDirect3DSwapChain9Ex::GetDisplayMode(THIS_ D3DDISPLAYMODE* pMode)
 
 	if (Config.D3d9to9Ex && ProxyInterfaceEx)
 	{
-		D3DDISPLAYMODEEX ModeEx = {};
-		ModeEx.Size = sizeof(D3DDISPLAYMODEEX);
-		D3DDISPLAYROTATION Rotation = D3DDISPLAYROTATION_IDENTITY;
-
-		HRESULT result = GetDisplayModeEx(&ModeEx, &Rotation);
-		if (result != D3D_OK || !pMode)
+		if (!pMode)
 		{
 			return D3DERR_INVALIDCALL;
 		}
 
-		m_IDirect3DDevice9Ex::ModeExToMode(ModeEx, *pMode);
-		return D3D_OK;
+		D3DDISPLAYMODEEX ModeEx = {};
+		ModeEx.Size = sizeof(D3DDISPLAYMODEEX);
+		D3DDISPLAYROTATION Rotation = D3DDISPLAYROTATION_IDENTITY;
+
+		HRESULT hr = GetDisplayModeEx(&ModeEx, &Rotation);
+
+		if (SUCCEEDED(hr))
+		{
+			m_IDirect3DDevice9Ex::ModeExToMode(ModeEx, *pMode);
+		}
+
+		return hr;
 	}
 
 	return ProxyInterface->GetDisplayMode(pMode);


### PR DESCRIPTION
Code was attempting to convert the Mode struct to ModeEx; since pMode is an out param the conversion should be the opposite. Fixes #415.