### PR TITLE
[dd7to9] fix GetScanLine return val

### DIFF
--- a/ddraw/IDirectDrawX.cpp
+++ b/ddraw/IDirectDrawX.cpp
@@ -1533,7 +1533,10 @@ HRESULT m_IDirectDrawX::GetScanLine(LPDWORD lpdwScanLine)
 		}
 
 		*lpdwScanLine = RasterStatus.ScanLine;
-
+		if (RasterStatus.InVBlank)
+		{
+			return DDERR_VERTICALBLANKINPROGRESS;
+		}
 		return DD_OK;
 	}
 


### PR DESCRIPTION
fix d7to9 GetScanLine return val when InVBlank = true, some game like crossgate(mmorpg) use DDERR_VERTICALBLANKINPROGRESS
