### PR TITLE
Alternative mouse cursor clipping using ClipCursor

### DIFF
--- a/GDI/WndProc.cpp
+++ b/GDI/WndProc.cpp
@@ -558,7 +558,7 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		}
 
 		// Enable mouse cursor clipping
-		if( Config.DdrawEnableCursorClip && Utils::PrimarySurfaceWidth > 0 && Utils::PrimarySurfaceHeight > 0 ) {
+		if( Config.DdrawEnableCursorClip ) {
 			Utils::ClipMouseCursor( hWnd, Utils::PrimarySurfaceWidth, Utils::PrimarySurfaceHeight );
 		}
 		break;

--- a/GDI/WndProc.cpp
+++ b/GDI/WndProc.cpp
@@ -654,7 +654,6 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		}
 		break;
 
-	case WM_WINDOWPOSCHANGING:
 	case WM_WINDOWPOSCHANGED:
 		if (lParam)
 		{
@@ -674,6 +673,13 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 			{
 				HandleClipMouseCursor(hWnd, pDataStruct, true);
 			}
+		}
+		[[fallthrough]];
+	case WM_WINDOWPOSCHANGING:
+		if (lParam)
+		{
+			WINDOWPOS* WinPos = reinterpret_cast<WINDOWPOS*>(lParam);
+
 			// Handle exclusive mode cases where the window is resized to be different than the display size
 			if (pDataStruct->IsDirectDraw && pDataStruct->IsExclusiveMode)
 			{

--- a/GDI/WndProc.cpp
+++ b/GDI/WndProc.cpp
@@ -40,6 +40,8 @@ namespace WndProc
 
 	bool SwitchingResolution = false;
 
+	void HandleWindowFocus(HWND hWnd, DATASTRUCT* pDataStruct, bool IsActivating);
+
 	std::atomic<bool> IsKeyboardActive = false;
 	void SetKeyboardLayoutFocus(HWND hWnd, bool IsActivating);
 
@@ -335,7 +337,29 @@ DWORD WndProc::MakeKey(DWORD Val1, DWORD Val2)
 	return Mix(Result);
 }
 
-void WndProc::SetKeyboardLayoutFocus(HWND hWnd, bool IsActivating)
+inline void WndProc::HandleWindowFocus(HWND hWnd, DATASTRUCT* pDataStruct, bool IsActivating)
+{
+	// Handle keyboard layout
+	if (Config.ForceKeyboardLayout)
+	{
+		SetKeyboardLayoutFocus(hWnd, IsActivating);
+	}
+
+	// Handle window clipping
+	if (Config.EnableCursorClip && pDataStruct->IsDirect3D9)
+	{
+		if (IsActivating)
+		{
+			Utils::ClipMouseCursor(hWnd, pDataStruct->ClipWidth, pDataStruct->ClipHeight);
+		}
+		else
+		{
+			Utils::UnClipMouseCursor();
+		}
+	}
+}
+
+inline void WndProc::SetKeyboardLayoutFocus(HWND hWnd, bool IsActivating)
 {
 	// On Activation
 	if (IsActivating)
@@ -424,11 +448,9 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		break;
 
 	case WM_ACTIVATEAPP:
-		// Handle keyboard layout
-		if (Config.ForceKeyboardLayout)
-		{
-			SetKeyboardLayoutFocus(hWnd, wParam != FALSE);
-		}
+		// Handle window focus change
+		HandleWindowFocus(hWnd, pDataStruct, wParam != FALSE);
+
 		// Some games don't properly handle app activate in exclusive mode
 		if (pDataStruct->IsDirectDraw)
 		{
@@ -451,11 +473,9 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		break;
 
 	case WM_ACTIVATE:
-		// Handle keyboard layout
-		if (Config.ForceKeyboardLayout)
-		{
-			SetKeyboardLayoutFocus(hWnd, LOWORD(wParam) != WA_INACTIVE);
-		}
+		// Handle window focus change
+		HandleWindowFocus(hWnd, pDataStruct, LOWORD(wParam) != WA_INACTIVE);
+
 		// Filter duplicate messages when using DirectDraw
 		if (pDataStruct->IsDirectDraw)
 		{
@@ -531,11 +551,9 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		break;
 
 	case WM_NCACTIVATE:
-		// Handle keyboard layout
-		if (Config.ForceKeyboardLayout)
-		{
-			SetKeyboardLayoutFocus(hWnd, LOWORD(wParam) != FALSE);
-		}
+		// Handle window focus change
+		HandleWindowFocus(hWnd, pDataStruct, LOWORD(wParam) != FALSE);
+
 		// Filter messages for loss of focus or minimize
 		if (Config.HideWindowFocusChanges && wParam == FALSE)
 		{
@@ -551,29 +569,13 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		break;
 
 	case WM_SETFOCUS:
-		// Handle keyboard layout
-		if (Config.ForceKeyboardLayout)
-		{
-			SetKeyboardLayoutFocus(hWnd, true);
-		}
-
-		// Enable mouse cursor clipping
-		if( Config.DdrawEnableCursorClip ) {
-			Utils::ClipMouseCursor( hWnd, Utils::PrimarySurfaceWidth, Utils::PrimarySurfaceHeight );
-		}
+		// Handle window focus change
+		HandleWindowFocus(hWnd, pDataStruct, true);
 		break;
 
 	case WM_KILLFOCUS:
-		// Handle keyboard layout
-		if (Config.ForceKeyboardLayout)
-		{
-			SetKeyboardLayoutFocus(hWnd, false);
-		}
-
-		// Disable mouse cursor clipping
-		if( Config.DdrawEnableCursorClip ) {
-			Utils::UnClipMouseCursor();
-		}
+		// Handle window focus change
+		HandleWindowFocus(hWnd, pDataStruct, false);
 
 		// Filter messages for loss of focus or minimize
 		if (Config.HideWindowFocusChanges && wParam == FALSE)
@@ -583,11 +585,9 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		break;
 
 	case WM_SHOWWINDOW:
-		// Handle keyboard layout
-		if (Config.ForceKeyboardLayout)
-		{
-			SetKeyboardLayoutFocus(hWnd, wParam != FALSE);
-		}
+		// Handle window focus change
+		HandleWindowFocus(hWnd, pDataStruct, wParam != FALSE);
+
 		// Filter messages for loss of focus or minimize
 		if (Config.HideWindowFocusChanges && wParam == FALSE)
 		{
@@ -610,11 +610,9 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		break;
 
 	case WM_SIZE:
-		// Handle keyboard layout
-		if (Config.ForceKeyboardLayout)
-		{
-			SetKeyboardLayoutFocus(hWnd, wParam != SIZE_MINIMIZED);
-		}
+		// Handle window focus change
+		HandleWindowFocus(hWnd, pDataStruct, wParam != SIZE_MINIMIZED);
+
 		// Filter messages for loss of focus or minimize
 		if (Config.HideWindowFocusChanges && wParam == SIZE_MINIMIZED)
 		{
@@ -651,10 +649,19 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		{
 			WINDOWPOS* WinPos = reinterpret_cast<WINDOWPOS*>(lParam);
 
-			// Handle keyboard layout
-			if (Config.ForceKeyboardLayout && (WinPos->flags & (SWP_SHOWWINDOW | SWP_HIDEWINDOW)))
+			// Handle window focus change
+			if (WinPos->flags & SWP_HIDEWINDOW)
 			{
-				SetKeyboardLayoutFocus(hWnd, (WinPos->flags & SWP_SHOWWINDOW));
+				HandleWindowFocus(hWnd, pDataStruct, false);
+			}
+			else if (WinPos->flags & SWP_SHOWWINDOW)
+			{
+				HandleWindowFocus(hWnd, pDataStruct, true);
+			}
+			else if (Config.EnableCursorClip && pDataStruct->IsDirect3D9 &&
+				(hWnd == GetFocus() || hWnd == GetActiveWindow() || hWnd == GetForegroundWindow()))
+			{
+				Utils::ClipMouseCursor(hWnd, pDataStruct->ClipWidth, pDataStruct->ClipHeight);
 			}
 			// Handle exclusive mode cases where the window is resized to be different than the display size
 			if (pDataStruct->IsDirectDraw && pDataStruct->IsExclusiveMode)
@@ -720,10 +727,10 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		{
 			AppWndProcInstance->SetInactive();
 		}
-		// Handle keyboard layout
-		if (Config.ForceKeyboardLayout && ((wParam & 0xFFF0) == SC_MINIMIZE || (wParam & 0xFFF0) == SC_MAXIMIZE))
+		// Handle window focus change
+		if ((wParam & 0xFFF0) == SC_MINIMIZE || (wParam & 0xFFF0) == SC_MAXIMIZE)
 		{
-			SetKeyboardLayoutFocus(hWnd, (wParam & 0xFFF0) == SC_MAXIMIZE);
+			HandleWindowFocus(hWnd, pDataStruct, (wParam & 0xFFF0) == SC_MAXIMIZE);
 		}
 		// Filter messages for loss of focus or minimize
 		if (Config.HideWindowFocusChanges && (wParam & 0xFFF0) == SC_MINIMIZE)
@@ -735,11 +742,9 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 	case WM_CLOSE:
 	case WM_DESTROY:
 	case WM_NCDESTROY:
-		// Handle keyboard layout
-		if (Config.ForceKeyboardLayout)
-		{
-			SetKeyboardLayoutFocus(hWnd, false);
-		}
+		// Handle window focus change
+		HandleWindowFocus(hWnd, pDataStruct, false);
+
 		// Set instance as inactive when window closes
 		AppWndProcInstance->SetInactive();
 		break;

--- a/GDI/WndProc.cpp
+++ b/GDI/WndProc.cpp
@@ -39,6 +39,7 @@ namespace WndProc
 	bool IsExecutableAddress(void* address);
 
 	bool SwitchingResolution = false;
+	DWORD PrimarySurfaceWidth = 0, PrimarySurfaceHeight = 0;
 
 	std::atomic<bool> IsKeyboardActive = false;
 	void SetKeyboardLayoutFocus(HWND hWnd, bool IsActivating);
@@ -556,6 +557,11 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		{
 			SetKeyboardLayoutFocus(hWnd, true);
 		}
+
+		// Enable mouse cursor clipping
+		if( Config.DdrawEnableCursorClip && PrimarySurfaceWidth > 0 && PrimarySurfaceHeight > 0 ) {
+			Utils::ClipMouseCursor( hWnd, PrimarySurfaceWidth, PrimarySurfaceHeight );
+		}
 		break;
 
 	case WM_KILLFOCUS:
@@ -564,6 +570,12 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		{
 			SetKeyboardLayoutFocus(hWnd, false);
 		}
+
+		// Disable mouse cursor clipping
+		if( Config.DdrawEnableCursorClip ) {
+			Utils::UnClipMouseCursor();
+		}
+
 		// Filter messages for loss of focus or minimize
 		if (Config.HideWindowFocusChanges && wParam == FALSE)
 		{

--- a/GDI/WndProc.cpp
+++ b/GDI/WndProc.cpp
@@ -41,6 +41,7 @@ namespace WndProc
 	bool SwitchingResolution = false;
 
 	void HandleWindowFocus(HWND hWnd, DATASTRUCT* pDataStruct, bool IsActivating);
+	void HandleClipMouseCursor(HWND hWnd, DATASTRUCT* pDataStruct, bool IsActivating);
 
 	std::atomic<bool> IsKeyboardActive = false;
 	void SetKeyboardLayoutFocus(HWND hWnd, bool IsActivating);
@@ -346,9 +347,14 @@ inline void WndProc::HandleWindowFocus(HWND hWnd, DATASTRUCT* pDataStruct, bool 
 	}
 
 	// Handle window clipping
+	HandleClipMouseCursor(hWnd, pDataStruct, IsActivating);
+}
+
+inline void WndProc::HandleClipMouseCursor(HWND hWnd, DATASTRUCT* pDataStruct, bool IsActivating)
+{
 	if (Config.EnableCursorClip && pDataStruct->IsDirect3D9)
 	{
-		if (IsActivating)
+		if (IsActivating && pDataStruct->InSizeMove == false)
 		{
 			Utils::ClipMouseCursor(hWnd, pDataStruct->ClipWidth, pDataStruct->ClipHeight);
 		}
@@ -628,10 +634,15 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		}
 		break;
 
-	case WM_STYLECHANGING:
-	case WM_STYLECHANGED:
 	case WM_ENTERSIZEMOVE:
 	case WM_EXITSIZEMOVE:
+		// Handle window focus change
+		pDataStruct->InSizeMove = (Msg == WM_ENTERSIZEMOVE);
+		HandleClipMouseCursor(hWnd, pDataStruct, true);
+
+		[[fallthrough]];
+	case WM_STYLECHANGING:
+	case WM_STYLECHANGED:
 	case WM_SIZING:
 	case WM_MOVING:
 		// Filter some messages when creating device
@@ -661,7 +672,7 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 			else if (Config.EnableCursorClip && pDataStruct->IsDirect3D9 &&
 				(hWnd == GetFocus() || hWnd == GetActiveWindow() || hWnd == GetForegroundWindow()))
 			{
-				Utils::ClipMouseCursor(hWnd, pDataStruct->ClipWidth, pDataStruct->ClipHeight);
+				HandleClipMouseCursor(hWnd, pDataStruct, true);
 			}
 			// Handle exclusive mode cases where the window is resized to be different than the display size
 			if (pDataStruct->IsDirectDraw && pDataStruct->IsExclusiveMode)

--- a/GDI/WndProc.cpp
+++ b/GDI/WndProc.cpp
@@ -39,7 +39,6 @@ namespace WndProc
 	bool IsExecutableAddress(void* address);
 
 	bool SwitchingResolution = false;
-	DWORD PrimarySurfaceWidth = 0, PrimarySurfaceHeight = 0;
 
 	std::atomic<bool> IsKeyboardActive = false;
 	void SetKeyboardLayoutFocus(HWND hWnd, bool IsActivating);
@@ -559,8 +558,8 @@ LRESULT CALLBACK WndProc::Handler(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		}
 
 		// Enable mouse cursor clipping
-		if( Config.DdrawEnableCursorClip && PrimarySurfaceWidth > 0 && PrimarySurfaceHeight > 0 ) {
-			Utils::ClipMouseCursor( hWnd, PrimarySurfaceWidth, PrimarySurfaceHeight );
+		if( Config.DdrawEnableCursorClip && Utils::PrimarySurfaceWidth > 0 && Utils::PrimarySurfaceHeight > 0 ) {
+			Utils::ClipMouseCursor( hWnd, Utils::PrimarySurfaceWidth, Utils::PrimarySurfaceHeight );
 		}
 		break;
 

--- a/GDI/WndProc.h
+++ b/GDI/WndProc.h
@@ -24,6 +24,7 @@ namespace WndProc
 	};
 
 	extern bool SwitchingResolution;
+	extern DWORD PrimarySurfaceWidth, PrimarySurfaceHeight;
 
 	bool ShouldHook(HWND hWnd);
 	DATASTRUCT* AddWndProc(HWND hWnd);

--- a/GDI/WndProc.h
+++ b/GDI/WndProc.h
@@ -23,6 +23,7 @@ namespace WndProc
 		DWORD DirectXVersion = 0;
 		LONG ClipWidth = 0;
 		LONG ClipHeight = 0;
+		bool InSizeMove = false;
 	};
 
 	extern bool SwitchingResolution;

--- a/GDI/WndProc.h
+++ b/GDI/WndProc.h
@@ -21,6 +21,8 @@ namespace WndProc
 		WORD IsWindowActive = 0xFFFF;
 		WORD IsWindowIconic = 0xFFFF;
 		DWORD DirectXVersion = 0;
+		LONG ClipWidth = 0;
+		LONG ClipHeight = 0;
 	};
 
 	extern bool SwitchingResolution;

--- a/GDI/WndProc.h
+++ b/GDI/WndProc.h
@@ -24,7 +24,6 @@ namespace WndProc
 	};
 
 	extern bool SwitchingResolution;
-	extern DWORD PrimarySurfaceWidth, PrimarySurfaceHeight;
 
 	bool ShouldHook(HWND hWnd);
 	DATASTRUCT* AddWndProc(HWND hWnd);

--- a/Settings/AllSettings.ini
+++ b/Settings/AllSettings.ini
@@ -100,6 +100,7 @@ DdrawOverrideHeight        = 0
 DdrawOverrideStencilFormat = 0
 DdrawIntegerScalingClamp   = 0
 DdrawMaintainAspectRatio   = 0
+DdrawEnableCursorClip      = 0
 
 [d3d9]
 AnisotropicFiltering       = 0

--- a/Settings/AllSettings.ini
+++ b/Settings/AllSettings.ini
@@ -100,7 +100,6 @@ DdrawOverrideHeight        = 0
 DdrawOverrideStencilFormat = 0
 DdrawIntegerScalingClamp   = 0
 DdrawMaintainAspectRatio   = 0
-DdrawEnableCursorClip      = 0
 
 [d3d9]
 AnisotropicFiltering       = 0
@@ -129,6 +128,7 @@ InitialWindowPositionLeft  = 0
 InitialWindowPositionTop   = 0
 FullscreenWindowMode       = 0
 HideWindowFocusChanges     = 0
+EnableCursorClip           = 0
 ForceExclusiveFullscreen   = 0
 ForceMixedVertexProcessing = 0
 ForceSystemMemVertexCache  = 0

--- a/Settings/Settings.h
+++ b/Settings/Settings.h
@@ -80,7 +80,7 @@ inline std::ostream& operator<<(std::ostream& os, const DHEX& dhex) {
 	visit(DdrawUseNativeResolution) \
 	visit(DdrawVertexLockDiscard) \
 	visit(DdrawEnableMouseHook) \
-	visit(DdrawEnableCursorClip) \
+	visit(EnableCursorClip) \
 	visit(DdrawHookSystem32) \
 	visit(D3d8HookSystem32) \
 	visit(D3d9HookSystem32) \
@@ -305,7 +305,7 @@ struct CONFIG
 	bool DdrawFilterActivateApp = false;		// Filters the WM_ACTIVATEAPP from the game, some games have issues with this message
 	bool DdrawForceMipMapAutoGen = false;		// Force Direct3d9 to use this AutoGenMipMap when using Dd7to9
 	bool DdrawEnableMouseHook = false;			// Allow to hook into mouse to limit it to the chosen resolution
-	bool DdrawEnableCursorClip = false;			// Use ClipCursor system to limit mouse movement
+	bool EnableCursorClip = false;			// Use ClipCursor system to limit mouse movement
 	DWORD DdrawHookSystem32 = 0;				// Hooks the ddraw.dll file in the Windows System32 folder
 	DWORD D3d8HookSystem32 = 0;					// Hooks the d3d8.dll file in the Windows System32 folder
 	bool D3d9HookSystem32 = false;				// Hooks the d3d9.dll file in the Windows System32 folder

--- a/Settings/Settings.h
+++ b/Settings/Settings.h
@@ -80,6 +80,7 @@ inline std::ostream& operator<<(std::ostream& os, const DHEX& dhex) {
 	visit(DdrawUseNativeResolution) \
 	visit(DdrawVertexLockDiscard) \
 	visit(DdrawEnableMouseHook) \
+	visit(DdrawEnableCursorClip) \
 	visit(DdrawHookSystem32) \
 	visit(D3d8HookSystem32) \
 	visit(D3d9HookSystem32) \
@@ -304,6 +305,7 @@ struct CONFIG
 	bool DdrawFilterActivateApp = false;		// Filters the WM_ACTIVATEAPP from the game, some games have issues with this message
 	bool DdrawForceMipMapAutoGen = false;		// Force Direct3d9 to use this AutoGenMipMap when using Dd7to9
 	bool DdrawEnableMouseHook = false;			// Allow to hook into mouse to limit it to the chosen resolution
+	bool DdrawEnableCursorClip = false;			// Use ClipCursor system to limit mouse movement
 	DWORD DdrawHookSystem32 = 0;				// Hooks the ddraw.dll file in the Windows System32 folder
 	DWORD D3d8HookSystem32 = 0;					// Hooks the d3d8.dll file in the Windows System32 folder
 	bool D3d9HookSystem32 = false;				// Hooks the d3d9.dll file in the Windows System32 folder

--- a/Utils/Utils.cpp
+++ b/Utils/Utils.cpp
@@ -1703,7 +1703,7 @@ LRESULT CALLBACK Utils::WndProcFilter(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 void Utils::ClipMouseCursor( HWND hWnd, const LONG clipWidth, const LONG clipHeight ) {
 	Logging::LogDebug() << __FUNCTION__ << " " << hWnd << " " << clipWidth << "x" << clipHeight;
 
-	if( !hWnd || clipWidth < 1 || clipHeight < 1 ) {// || hWnd != GetForegroundWindow()) {
+	if( !hWnd || !IsWindow( hWnd ) || clipWidth < 1 || clipHeight < 1 ) {
 		return;
 	}
 

--- a/Utils/Utils.cpp
+++ b/Utils/Utils.cpp
@@ -1707,22 +1707,38 @@ void Utils::ClipMouseCursor(HWND hWnd, const LONG clipWidth, const LONG clipHeig
 		return;
 	}
 
-	RECT winRect, clientRect;
+	RECT clientRect;
 
-	if (GetWindowRect(hWnd, &winRect) && GetClientRect(hWnd, &clientRect))
+	if (GetClientRect(hWnd, &clientRect))
 	{
-		// If window client is larger use clipWidth/clipHeight
-		if (clientRect.right > clipWidth || clientRect.bottom > clipHeight)
-		{
-			RECT clipRect = { winRect.left, winRect.top, winRect.left + clipWidth, winRect.top + clipHeight };
+		POINT clientTopLeft = { 0, 0 };
 
-			ClipCursor(&clipRect);
+		ClientToScreen( hWnd, &clientTopLeft );
+
+		RECT clipRect = {
+			clientTopLeft.x,
+			clientTopLeft.y,
+			clientTopLeft.x,
+			clientTopLeft.y
+		};
+
+		LONG clientWidth = clientRect.right - clientRect.left;
+		LONG clientHeight = clientRect.bottom - clientRect.top;
+
+		// If window client is larger use clipWidth/clipHeight
+		if (clientWidth > clipWidth || clientHeight > clipHeight)
+		{
+			clipRect.right += clipWidth;
+			clipRect.bottom += clipHeight;
 		}
-		// Use window size
+		// Use client size
 		else
 		{
-			ClipCursor(&winRect);
+			clipRect.right += clientWidth;
+			clipRect.bottom += clientHeight;
 		}
+
+		ClipCursor(&clipRect);
 	}
 }
 

--- a/Utils/Utils.cpp
+++ b/Utils/Utils.cpp
@@ -145,8 +145,6 @@ namespace Utils
 	uint64_t PerformanceFrequency_real = 0;
 	constexpr uint64_t PerformanceFrequency_cap = 0xFFFFFFFF;
 
-	DWORD PrimarySurfaceWidth = 0, PrimarySurfaceHeight = 0;
-
 	// Function declarations
 	ULONGLONG GetTickCount64_Emulated();
 	void InitializeASI(HMODULE hModule);
@@ -1700,29 +1698,42 @@ LRESULT CALLBACK Utils::WndProcFilter(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 	return DefWindowProc(hWnd, uMsg, wParam, lParam);
 }
 
-void Utils::ClipMouseCursor( HWND hWnd, const LONG clipWidth, const LONG clipHeight ) {
-	Logging::LogDebug() << __FUNCTION__ << " " << hWnd << " " << clipWidth << "x" << clipHeight;
+void Utils::ClipMouseCursor(HWND hWnd, const LONG clipWidth, const LONG clipHeight)
+{
+	Logging::LogDebug() << __FUNCTION__ << " " << hWnd;
 
-	if( !IsWindow( hWnd ) || clipWidth < 1 || clipHeight < 1 ) {
+	if (!IsWindow(hWnd) || clipWidth < 1 || clipHeight < 1)
+	{
 		return;
 	}
 
 	RECT winRect, clientRect;
 
-	if( GetWindowRect( hWnd, &winRect ) && GetClientRect( hWnd, &clientRect )) {
-		RECT clipRect;
+	if (GetWindowRect(hWnd, &winRect) && GetClientRect(hWnd, &clientRect))
+	{
+		// If window is larger use clipWidth/clipHeight
+		if (winRect.right - winRect.left > clipWidth && winRect.bottom - winRect.top > clipHeight)
+		{
+			RECT clipRect;
 
-		clipRect.top = clientRect.top + winRect.top;
-		clipRect.left = clientRect.left + winRect.left;
-		clipRect.bottom = clipRect.top + clipHeight;
-		clipRect.right = clipRect.left + clipWidth;
+			clipRect.left = clientRect.left + winRect.left;
+			clipRect.top = clientRect.top + winRect.top;
+			clipRect.right = clipRect.left + clipWidth;
+			clipRect.bottom = clipRect.top + clipHeight;
 
-		ClipCursor( &clipRect );
+			ClipCursor(&clipRect);
+		}
+		// Use window size
+		else
+		{
+			ClipCursor(&winRect);
+		}
 	}
 }
 
-void Utils::UnClipMouseCursor() {
+void Utils::UnClipMouseCursor()
+{
 	Logging::LogDebug() << __FUNCTION__;
 
-	ClipCursor( nullptr );
+	ClipCursor(nullptr);
 }

--- a/Utils/Utils.cpp
+++ b/Utils/Utils.cpp
@@ -145,6 +145,8 @@ namespace Utils
 	uint64_t PerformanceFrequency_real = 0;
 	constexpr uint64_t PerformanceFrequency_cap = 0xFFFFFFFF;
 
+	DWORD PrimarySurfaceWidth = 0, PrimarySurfaceHeight = 0;
+
 	// Function declarations
 	ULONGLONG GetTickCount64_Emulated();
 	void InitializeASI(HMODULE hModule);

--- a/Utils/Utils.cpp
+++ b/Utils/Utils.cpp
@@ -1713,30 +1713,19 @@ void Utils::ClipMouseCursor(HWND hWnd, const LONG clipWidth, const LONG clipHeig
 	{
 		POINT clientTopLeft = { 0, 0 };
 
-		ClientToScreen( hWnd, &clientTopLeft );
+		ClientToScreen(hWnd, &clientTopLeft);
+
+		LONG clientWidth = clientRect.right - clientRect.left;
+		LONG clientHeight = clientRect.bottom - clientRect.top;
+		// If window client is larger use clipWidth/clipHeight
+		bool useClipSize = (clientWidth > clipWidth || clientHeight > clipHeight);
 
 		RECT clipRect = {
 			clientTopLeft.x,
 			clientTopLeft.y,
-			clientTopLeft.x,
-			clientTopLeft.y
+			clientTopLeft.x + (useClipSize ? clipWidth : clientWidth),
+			clientTopLeft.y + (useClipSize ? clipHeight : clientHeight)
 		};
-
-		LONG clientWidth = clientRect.right - clientRect.left;
-		LONG clientHeight = clientRect.bottom - clientRect.top;
-
-		// If window client is larger use clipWidth/clipHeight
-		if (clientWidth > clipWidth || clientHeight > clipHeight)
-		{
-			clipRect.right += clipWidth;
-			clipRect.bottom += clipHeight;
-		}
-		// Use client size
-		else
-		{
-			clipRect.right += clientWidth;
-			clipRect.bottom += clientHeight;
-		}
 
 		ClipCursor(&clipRect);
 	}

--- a/Utils/Utils.cpp
+++ b/Utils/Utils.cpp
@@ -1697,3 +1697,30 @@ LRESULT CALLBACK Utils::WndProcFilter(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 	return DefWindowProc(hWnd, uMsg, wParam, lParam);
 }
+
+void Utils::ClipMouseCursor( HWND hWnd, const LONG clipWidth, const LONG clipHeight ) {
+	Logging::LogDebug() << __FUNCTION__ << " " << hWnd << " " << clipWidth << "x" << clipHeight;
+
+	if( !hWnd || clipWidth < 1 || clipHeight < 1 ) {// || hWnd != GetForegroundWindow()) {
+		return;
+	}
+
+	RECT winRect, clientRect;
+
+	if( GetWindowRect( hWnd, &winRect ) && GetClientRect( hWnd, &clientRect )) {
+		RECT clipRect;
+
+		clipRect.top = clientRect.top + winRect.top;
+		clipRect.left = clientRect.left + winRect.left;
+		clipRect.bottom = clipRect.top + clipHeight;
+		clipRect.right = clipRect.left + clipWidth;
+
+		ClipCursor( &clipRect );
+	}
+}
+
+void Utils::UnClipMouseCursor() {
+	Logging::LogDebug() << __FUNCTION__;
+
+	ClipCursor( nullptr );
+}

--- a/Utils/Utils.cpp
+++ b/Utils/Utils.cpp
@@ -1711,15 +1711,10 @@ void Utils::ClipMouseCursor(HWND hWnd, const LONG clipWidth, const LONG clipHeig
 
 	if (GetWindowRect(hWnd, &winRect) && GetClientRect(hWnd, &clientRect))
 	{
-		// If window is larger use clipWidth/clipHeight
-		if (winRect.right - winRect.left > clipWidth && winRect.bottom - winRect.top > clipHeight)
+		// If window client is larger use clipWidth/clipHeight
+		if (clientRect.right > clipWidth || clientRect.bottom > clipHeight)
 		{
-			RECT clipRect;
-
-			clipRect.left = clientRect.left + winRect.left;
-			clipRect.top = clientRect.top + winRect.top;
-			clipRect.right = clipRect.left + clipWidth;
-			clipRect.bottom = clipRect.top + clipHeight;
+			RECT clipRect = { winRect.left, winRect.top, winRect.left + clipWidth, winRect.top + clipHeight };
 
 			ClipCursor(&clipRect);
 		}

--- a/Utils/Utils.cpp
+++ b/Utils/Utils.cpp
@@ -1703,7 +1703,7 @@ LRESULT CALLBACK Utils::WndProcFilter(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 void Utils::ClipMouseCursor( HWND hWnd, const LONG clipWidth, const LONG clipHeight ) {
 	Logging::LogDebug() << __FUNCTION__ << " " << hWnd << " " << clipWidth << "x" << clipHeight;
 
-	if( !hWnd || !IsWindow( hWnd ) || clipWidth < 1 || clipHeight < 1 ) {
+	if( !IsWindow( hWnd ) || clipWidth < 1 || clipHeight < 1 ) {
 		return;
 	}
 

--- a/Utils/Utils.cpp
+++ b/Utils/Utils.cpp
@@ -1702,33 +1702,30 @@ void Utils::ClipMouseCursor(HWND hWnd, const LONG clipWidth, const LONG clipHeig
 {
 	Logging::LogDebug() << __FUNCTION__ << " " << hWnd;
 
-	if (!IsWindow(hWnd) || clipWidth < 1 || clipHeight < 1)
+	RECT clientRect;
+
+	if (!IsWindow(hWnd) || !GetClientRect(hWnd, &clientRect) || clipWidth < 1 || clipHeight < 1)
 	{
 		return;
 	}
 
-	RECT clientRect;
+	POINT clientTopLeft = { 0, 0 };
 
-	if (GetClientRect(hWnd, &clientRect))
-	{
-		POINT clientTopLeft = { 0, 0 };
+	ClientToScreen(hWnd, &clientTopLeft);
 
-		ClientToScreen(hWnd, &clientTopLeft);
+	LONG clientWidth = clientRect.right - clientRect.left;
+	LONG clientHeight = clientRect.bottom - clientRect.top;
+	// If window client is larger use clipWidth/clipHeight
+	bool useClipSize = (clientWidth > clipWidth || clientHeight > clipHeight);
 
-		LONG clientWidth = clientRect.right - clientRect.left;
-		LONG clientHeight = clientRect.bottom - clientRect.top;
-		// If window client is larger use clipWidth/clipHeight
-		bool useClipSize = (clientWidth > clipWidth || clientHeight > clipHeight);
+	RECT clipRect = {
+		clientTopLeft.x,
+		clientTopLeft.y,
+		clientTopLeft.x + (useClipSize ? clipWidth : clientWidth),
+		clientTopLeft.y + (useClipSize ? clipHeight : clientHeight)
+	};
 
-		RECT clipRect = {
-			clientTopLeft.x,
-			clientTopLeft.y,
-			clientTopLeft.x + (useClipSize ? clipWidth : clientWidth),
-			clientTopLeft.y + (useClipSize ? clipHeight : clientHeight)
-		};
-
-		ClipCursor(&clipRect);
-	}
+	ClipCursor(&clipRect);
 }
 
 void Utils::UnClipMouseCursor()

--- a/Utils/Utils.h
+++ b/Utils/Utils.h
@@ -108,6 +108,8 @@ namespace Utils
 	void GetScreenSize(HMONITOR hMonitor, volatile LONG &screenWidth, volatile LONG &screenHeight);
 	void GetScreenSize(HMONITOR hMonitor, int& screenWidth, int& screenHeight);
 	void GetScreenClientRect(HMONITOR hMonitor, RECT& workAreaOut);
+	void ClipMouseCursor( HWND hWnd, const LONG clipWidth, const LONG clipHeight );
+	void UnClipMouseCursor();
 
 	// CPU Affinity
 	void SetProcessAffinity();

--- a/Utils/Utils.h
+++ b/Utils/Utils.h
@@ -108,7 +108,7 @@ namespace Utils
 	void GetScreenSize(HMONITOR hMonitor, volatile LONG &screenWidth, volatile LONG &screenHeight);
 	void GetScreenSize(HMONITOR hMonitor, int& screenWidth, int& screenHeight);
 	void GetScreenClientRect(HMONITOR hMonitor, RECT& workAreaOut);
-	void ClipMouseCursor( HWND hWnd, const LONG clipWidth, const LONG clipHeight );
+	void ClipMouseCursor(HWND hWnd, const LONG clipWidth, const LONG clipHeight);
 	void UnClipMouseCursor();
 
 	// CPU Affinity
@@ -158,8 +158,6 @@ namespace Utils
 			Sleep(0); // Let the OS schedule other tasks if there's significant time left
 		}
 	}
-
-	extern DWORD PrimarySurfaceWidth, PrimarySurfaceHeight;
 }
 
 namespace WriteMemory

--- a/Utils/Utils.h
+++ b/Utils/Utils.h
@@ -158,6 +158,8 @@ namespace Utils
 			Sleep(0); // Let the OS schedule other tasks if there's significant time left
 		}
 	}
+
+	extern DWORD PrimarySurfaceWidth, PrimarySurfaceHeight;
 }
 
 namespace WriteMemory

--- a/d3d9/IDirect3D9Ex.cpp
+++ b/d3d9/IDirect3D9Ex.cpp
@@ -516,6 +516,8 @@ HRESULT m_IDirect3D9Ex::CreateDeviceT(DEVICEDETAILS& DeviceDetails, UINT Adapter
 		{
 			// Already set by DirectDraw
 			WndDataStruct->IsExclusiveMode = !pPresentationParameters->Windowed;
+			WndDataStruct->ClipWidth = pPresentationParameters->BackBufferWidth;
+			WndDataStruct->ClipHeight = pPresentationParameters->BackBufferHeight;
 		}
 		DeviceDetails.IsDirectDrawDevice = WndDataStruct->IsDirectDraw;
 	}
@@ -638,6 +640,12 @@ HRESULT m_IDirect3D9Ex::CreateDeviceT(DEVICEDETAILS& DeviceDetails, UINT Adapter
 			}
 
 			CopyMemory(pPresentationParameters, p_d3dpp, sizeof(D3DPRESENT_PARAMETERS));
+
+			// Enable mouse clipping
+			if (Config.EnableCursorClip && !DeviceDetails.IsDirectDrawDevice && WndDataStruct)
+			{
+				Utils::ClipMouseCursor(DeviceDetails.DeviceWindow, WndDataStruct->ClipWidth, WndDataStruct->ClipHeight);
+			}
 		}
 	}
 

--- a/ddraw/IDirectDrawSurfaceX.cpp
+++ b/ddraw/IDirectDrawSurfaceX.cpp
@@ -19,6 +19,7 @@
 #include <deque>
 #include <fstream>
 #include "Utils\Utils.h"
+#include "GDI\WndProc.h"
 
 #define CheckCreateInterface(interfacex, name, device, surface, lost) \
 { \
@@ -4606,13 +4607,20 @@ HRESULT m_IDirectDrawSurfaceX::CreateD9Surface()
 
 	Logging::LogDebug() << __FUNCTION__ " (" << this << ") D3d9 Surface. Size: " << surface.Width << "x" << surface.Height << " Format: " << surface.Format <<
 		" Pool: " << surface.Pool << " dwCaps: " << surfaceDesc2.ddsCaps << " " << surfaceDesc2;
-	
-	// Save primary surface size info for use with ie. mouse clipping
-	if( surfaceDesc2.ddsCaps.dwCaps & DDSCAPS_PRIMARYSURFACE && Config.DdrawEnableCursorClip ) {
-		Utils::PrimarySurfaceWidth = surface.Width;
-		Utils::PrimarySurfaceHeight = surface.Height;
 
-		Utils::ClipMouseCursor( ddrawParent->GetHwnd(), surface.Width, surface.Height );
+	// Save primary surface size info for use with ie. mouse clipping
+	if (Config.EnableCursorClip && IsPrimarySurface())
+	{
+		HWND hWnd = ddrawParent->GetHwnd();
+		WndProc::DATASTRUCT* WndDataStruct = WndProc::AddWndProc(hWnd);
+
+		if (WndDataStruct)
+		{
+			WndDataStruct->ClipWidth = surface.Width;
+			WndDataStruct->ClipHeight = surface.Height;
+
+			Utils::ClipMouseCursor(hWnd, surface.Width, surface.Height);
+		}
 	}
 
 	HRESULT hr = DD_OK;

--- a/ddraw/IDirectDrawSurfaceX.cpp
+++ b/ddraw/IDirectDrawSurfaceX.cpp
@@ -19,7 +19,6 @@
 #include <deque>
 #include <fstream>
 #include "Utils\Utils.h"
-#include "GDI/WndProc.h"
 
 #define CheckCreateInterface(interfacex, name, device, surface, lost) \
 { \

--- a/ddraw/IDirectDrawSurfaceX.cpp
+++ b/ddraw/IDirectDrawSurfaceX.cpp
@@ -19,6 +19,7 @@
 #include <deque>
 #include <fstream>
 #include "Utils\Utils.h"
+#include "GDI/WndProc.h"
 
 #define CheckCreateInterface(interfacex, name, device, surface, lost) \
 { \
@@ -4606,6 +4607,14 @@ HRESULT m_IDirectDrawSurfaceX::CreateD9Surface()
 
 	Logging::LogDebug() << __FUNCTION__ " (" << this << ") D3d9 Surface. Size: " << surface.Width << "x" << surface.Height << " Format: " << surface.Format <<
 		" Pool: " << surface.Pool << " dwCaps: " << surfaceDesc2.ddsCaps << " " << surfaceDesc2;
+	
+	// Set primary surface size info for use in WndProc
+	if( surfaceDesc2.ddsCaps.dwCaps & DDSCAPS_PRIMARYSURFACE && Config.DdrawEnableCursorClip ) {
+		WndProc::PrimarySurfaceWidth = surface.Width;
+		WndProc::PrimarySurfaceHeight = surface.Height;
+
+		Utils::ClipMouseCursor( ddrawParent->GetHwnd(), surface.Width, surface.Height );
+	}
 
 	HRESULT hr = DD_OK;
 

--- a/ddraw/IDirectDrawSurfaceX.cpp
+++ b/ddraw/IDirectDrawSurfaceX.cpp
@@ -4608,10 +4608,10 @@ HRESULT m_IDirectDrawSurfaceX::CreateD9Surface()
 	Logging::LogDebug() << __FUNCTION__ " (" << this << ") D3d9 Surface. Size: " << surface.Width << "x" << surface.Height << " Format: " << surface.Format <<
 		" Pool: " << surface.Pool << " dwCaps: " << surfaceDesc2.ddsCaps << " " << surfaceDesc2;
 	
-	// Set primary surface size info for use in WndProc
+	// Save primary surface size info for use with ie. mouse clipping
 	if( surfaceDesc2.ddsCaps.dwCaps & DDSCAPS_PRIMARYSURFACE && Config.DdrawEnableCursorClip ) {
-		WndProc::PrimarySurfaceWidth = surface.Width;
-		WndProc::PrimarySurfaceHeight = surface.Height;
+		Utils::PrimarySurfaceWidth = surface.Width;
+		Utils::PrimarySurfaceHeight = surface.Height;
 
 		Utils::ClipMouseCursor( ddrawParent->GetHwnd(), surface.Width, surface.Height );
 	}


### PR DESCRIPTION
This is an alternative option to keep the mouse cursor inside the game window.
It uses [ClipCursor](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-clipcursor) instead of an extra thread.

EnableMouseHook does not seem to work in the game i tested ( Planescape Torment for example ), the mouse cursor still moved outside the window. Unless i'm misunderstanding what it is for ?

I'm sure this code is not optimal in where and how it's implemented / where variables are put etc, but it worked quite well when i tried it in these games. Proof of concept ?

A review / comments on how it is implemented are welcome.
There's probably better places to put the "Primary Surface Size Info" variables, i was a bit unsure where to put them.