### PR TITLE
[d3d9] Fix Anisotropic Filtering not fully working

### DIFF
--- a/Dllmain/BuildNo.rc
+++ b/Dllmain/BuildNo.rc
@@ -1,1 +1,1 @@
-#define BUILD_NUMBER 8600 
+#define BUILD_NUMBER 8601

--- a/Dllmain/BuildNo.rc
+++ b/Dllmain/BuildNo.rc
@@ -1,1 +1,1 @@
-#define BUILD_NUMBER 8601
+#define BUILD_NUMBER 8601 

--- a/d3d9/IDirect3D9Ex.cpp
+++ b/d3d9/IDirect3D9Ex.cpp
@@ -638,7 +638,6 @@ HRESULT m_IDirect3D9Ex::CreateDeviceT(DEVICEDETAILS& DeviceDetails, UINT Adapter
 			if (MultiSampleFlag || (pPresentationParameters->MultiSampleType && DeviceDetails.IsDirectDrawDevice))
 			{
 				DeviceDetails.DeviceMultiSampleFlag = true;
-				DeviceDetails.SetMultiSampleState = true;
 				DeviceDetails.DeviceMultiSampleType = d3dpp.MultiSampleType;
 				DeviceDetails.DeviceMultiSampleQuality = d3dpp.MultiSampleQuality;
 			}

--- a/d3d9/IDirect3DDevice9Ex.cpp
+++ b/d3d9/IDirect3DDevice9Ex.cpp
@@ -1606,12 +1606,10 @@ HRESULT m_IDirect3DDevice9Ex::SetSamplerState(THIS_ DWORD Sampler, D3DSAMPLERSTA
 		{
 			if (Value == D3DTEXF_NONE || Value == D3DTEXF_POINT)
 			{
-				DeviceDetails.SetMultiSampleState = false;
 				ProxyInterface->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, FALSE);
 			}
 			else
 			{
-				DeviceDetails.SetMultiSampleState = true;
 				ProxyInterface->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, TRUE);
 			}
 		}
@@ -1620,10 +1618,7 @@ HRESULT m_IDirect3DDevice9Ex::SetSamplerState(THIS_ DWORD Sampler, D3DSAMPLERSTA
 	// Force MipMap usage
 	if (Config.ForceMipMapUsage && Type == D3DSAMP_MIPFILTER)
 	{
-		if (SUCCEEDED(ProxyInterface->SetSamplerState(Sampler, Type, LinearMip ? D3DTEXF_LINEAR : D3DTEXF_POINT)))
-		{
-			return D3D_OK;
-		}
+		return D3D_OK;
 	}
 
 	// Enable Anisotropic Filtering
@@ -3536,8 +3531,6 @@ void m_IDirect3DDevice9Ex::ReInitInterface()
 	// Force MipMap usage
 	if (Config.ForceMipMapUsage)
 	{
-		LinearMip = (Caps.TextureFilterCaps & D3DPTFILTERCAPS_MIPFLINEAR);
-
 		for (UINT x = 0; x < D3DHAL_TSS_MAXSTAGES; x++)
 		{
 			ProxyInterface->SetSamplerState(x, D3DSAMP_MIPFILTER, LinearMip ? D3DTEXF_LINEAR : D3DTEXF_POINT);
@@ -3547,7 +3540,7 @@ void m_IDirect3DDevice9Ex::ReInitInterface()
 	// Set for Multisample
 	if (DeviceDetails.DeviceMultiSampleFlag)
 	{
-		if (DeviceDetails.SetMultiSampleState && !DeviceDetails.UseAppMultiSampleState)
+		if (!DeviceDetails.UseAppMultiSampleState)
 		{
 			ProxyInterface->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, TRUE);
 		}

--- a/d3d9/IDirect3DDevice9Ex.cpp
+++ b/d3d9/IDirect3DDevice9Ex.cpp
@@ -1180,36 +1180,6 @@ HRESULT m_IDirect3DDevice9Ex::BeginScene()
 	if (SUCCEEDED(hr))
 	{
 		AfterBeginScene();
-
-		// Set Max Anisotropy
-		if (MaxAnisotropy && (AnisotropyMin || AnisotropyMag))
-		{
-			for (UINT x = 0; x < D3DHAL_TSS_MAXSTAGES; x++)
-			{
-				ProxyInterface->SetSamplerState(x, D3DSAMP_MAXANISOTROPY, MaxAnisotropy);
-			}
-		}
-
-		// Set for Multisample
-		if (DeviceDetails.DeviceMultiSampleFlag)
-		{
-			if (DeviceDetails.SetMultiSampleState && !DeviceDetails.UseAppMultiSampleState)
-			{
-				ProxyInterface->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, TRUE);
-			}
-			if (DeviceDetails.SetSSAA)
-			{
-				ProxyInterface->SetRenderState(D3DRS_ADAPTIVETESS_Y, MAKEFOURCC('S', 'S', 'A', 'A'));
-			}
-			if (DeviceDetails.SetATOC)
-			{
-				ProxyInterface->SetRenderState(D3DRS_ADAPTIVETESS_Y, MAKEFOURCC('A', 'T', 'O', 'C'));
-				if (Config.EnableMultisamplingATOC == 2)
-				{
-					ProxyInterface->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
-				}
-			}
-		}
 	}
 
 	return hr;
@@ -1647,21 +1617,46 @@ HRESULT m_IDirect3DDevice9Ex::SetSamplerState(THIS_ DWORD Sampler, D3DSAMPLERSTA
 		}
 	}
 
+	// Force MipMap usage
+	if (Config.ForceMipMapUsage && Type == D3DSAMP_MIPFILTER)
+	{
+		if (SUCCEEDED(ProxyInterface->SetSamplerState(Sampler, Type, LinearMip ? D3DTEXF_LINEAR : D3DTEXF_POINT)))
+		{
+			return D3D_OK;
+		}
+	}
+
 	// Enable Anisotropic Filtering
 	if (MaxAnisotropy)
 	{
 		if (Type == D3DSAMP_MAXANISOTROPY)
 		{
-			if (SUCCEEDED(ProxyInterface->SetSamplerState(Sampler, D3DSAMP_MAXANISOTROPY, MaxAnisotropy)))
+			if (SUCCEEDED(ProxyInterface->SetSamplerState(Sampler, Type, MaxAnisotropy)))
 			{
 				return D3D_OK;
 			}
 		}
-		else if (((Type == D3DSAMP_MINFILTER && AnisotropyMin) || (Type == D3DSAMP_MAGFILTER && AnisotropyMag)) && Value != D3DTEXF_NONE && Value != D3DTEXF_POINT)
+		else if (AnisotropyMin && Type == D3DSAMP_MINFILTER && Value != D3DTEXF_NONE)
 		{
 			if (SUCCEEDED(ProxyInterface->SetSamplerState(Sampler, Type, D3DTEXF_ANISOTROPIC)))
 			{
 				LOG_ONCE("Setting Anisotropic Filtering at " << MaxAnisotropy << "x");
+				return D3D_OK;
+			}
+		}
+		// Anisotropic filtering is principally useful for minification, keeping MAGFILTER set to POINT
+		else if (AnisotropyMag && Type == D3DSAMP_MAGFILTER && Value != D3DTEXF_NONE && Value != D3DTEXF_POINT)
+		{
+			if (SUCCEEDED(ProxyInterface->SetSamplerState(Sampler, Type, D3DTEXF_ANISOTROPIC)))
+			{
+				LOG_ONCE("Setting Anisotropic Filtering at " << MaxAnisotropy << "x");
+				return D3D_OK;
+			}
+		}
+		else if (LinearMip && Type == D3DSAMP_MIPFILTER && Value != D3DTEXF_NONE)
+		{
+			if (SUCCEEDED(ProxyInterface->SetSamplerState(Sampler, Type, D3DTEXF_LINEAR)))
+			{
 				return D3D_OK;
 			}
 		}
@@ -3514,12 +3509,60 @@ void m_IDirect3DDevice9Ex::ReInitInterface()
 		Logging::Log() << __FUNCTION__ << " Error: Falied to get DeviceCaps (" << this << ")";
 	}
 
+	// Set Max Anisotropy and Anisotropic Filtering
 	if (Config.AnisotropicFiltering)
 	{
 		MaxAnisotropy = (Config.AnisotropicFiltering == 1) ? Caps.MaxAnisotropy : min((DWORD)Config.AnisotropicFiltering, Caps.MaxAnisotropy);
 		AnisotropyMin = (Caps.TextureFilterCaps & D3DPTFILTERCAPS_MINFANISOTROPIC);
 		AnisotropyMag = (Caps.TextureFilterCaps & D3DPTFILTERCAPS_MAGFANISOTROPIC);
-		LOG_ONCE("Anisotropic Filtering DeviceCaps. Min: " << AnisotropyMin << " Mag: " << AnisotropyMag);
+		LinearMip = (Caps.TextureFilterCaps & D3DPTFILTERCAPS_MIPFLINEAR);
+		LOG_ONCE("Anisotropic Filtering DeviceCaps. Min: " << AnisotropyMin << " Mag: " << AnisotropyMag << " LinearMap: " << LinearMip);
+
+		if (MaxAnisotropy && (AnisotropyMin || AnisotropyMag))
+		{
+			for (UINT x = 0; x < D3DHAL_TSS_MAXSTAGES; x++)
+			{
+				ProxyInterface->SetSamplerState(x, D3DSAMP_MAXANISOTROPY, MaxAnisotropy);
+
+				// Anisotropic filtering is principally useful for minification, keeping MAGFILTER set to POINT
+				if (AnisotropyMin)
+				{
+					ProxyInterface->SetSamplerState(x, D3DSAMP_MINFILTER, D3DTEXF_ANISOTROPIC);
+				}
+			}
+		}
+	}
+
+	// Force MipMap usage
+	if (Config.ForceMipMapUsage)
+	{
+		LinearMip = (Caps.TextureFilterCaps & D3DPTFILTERCAPS_MIPFLINEAR);
+
+		for (UINT x = 0; x < D3DHAL_TSS_MAXSTAGES; x++)
+		{
+			ProxyInterface->SetSamplerState(x, D3DSAMP_MIPFILTER, LinearMip ? D3DTEXF_LINEAR : D3DTEXF_POINT);
+		}
+	}
+
+	// Set for Multisample
+	if (DeviceDetails.DeviceMultiSampleFlag)
+	{
+		if (DeviceDetails.SetMultiSampleState && !DeviceDetails.UseAppMultiSampleState)
+		{
+			ProxyInterface->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, TRUE);
+		}
+		if (DeviceDetails.SetSSAA)
+		{
+			ProxyInterface->SetRenderState(D3DRS_ADAPTIVETESS_Y, MAKEFOURCC('S', 'S', 'A', 'A'));
+		}
+		if (DeviceDetails.SetATOC)
+		{
+			ProxyInterface->SetRenderState(D3DRS_ADAPTIVETESS_Y, MAKEFOURCC('A', 'T', 'O', 'C'));
+			if (Config.EnableMultisamplingATOC == 2)
+			{
+				ProxyInterface->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
+			}
+		}
 	}
 
 	ShadowBackbuffer->ReleaseAll();

--- a/d3d9/IDirect3DDevice9Ex.h
+++ b/d3d9/IDirect3DDevice9Ex.h
@@ -21,7 +21,6 @@ struct DEVICEDETAILS
 
 	// For AntiAliasing
 	bool DeviceMultiSampleFlag = false;
-	bool SetMultiSampleState = false;
 	bool UseAppMultiSampleState = false;
 	bool SetSSAA = false;
 	bool SetATOC = false;
@@ -118,7 +117,7 @@ private:
 	// Anisotropic Filtering
 	DWORD MaxAnisotropy = 0;
 
-	// Linear Filtering
+	// Mip Filtering
 	bool LinearMip = false;
 
 	// Antialiasing

--- a/d3d9/IDirect3DDevice9Ex.h
+++ b/d3d9/IDirect3DDevice9Ex.h
@@ -118,6 +118,9 @@ private:
 	// Anisotropic Filtering
 	DWORD MaxAnisotropy = 0;
 
+	// Linear Filtering
+	bool LinearMip = false;
+
 	// Antialiasing
 	struct {
 		bool MultiSampleMismatch = false;


### PR DESCRIPTION
While inspecting some new textures I made for my mod for the game Freelancer (2003), I noticed that the textures looked unusually blurry at specific distances, despite Anisotropic Filtering being enabled and set to 16x. A quick look at a PIX snapshot revealed that `D3DSAMP_MINFILTER` and `D3DSAMP_MAGFILTER` were **not** set at the start of the scene, and as a result many textures were rendered without anisotropic min and mag filtering. This pull request fixes that.

Additionally, note that I also set `D3DSAMP_MIPFILTER`. Freelancer does not set this state at the start of the scene either, and failing to do it manually results in the new code having no effect, at least in Freelancer.

Before:

<img width="125" height="125" alt="before" src="https://github.com/user-attachments/assets/ef004d8b-a10e-4302-87b2-3169e2f9499f" />

After:

<img width="125" height="125" alt="after" src="https://github.com/user-attachments/assets/342f0193-9839-481b-b77e-0070dea37574" />

